### PR TITLE
Fix anatGetFile to write to /tmp directory rather than common tmp.txt file in home directory

### DIFF
--- a/R/structure_funcs.R
+++ b/R/structure_funcs.R
@@ -3,8 +3,7 @@
 
 anatGetFile <- function(filename, atlas, method="jacobians", defs="/projects/mice/jlerch/cortex-label/c57_brain_atlas_labels.csv", dropLabels=FALSE, side="both" ) {
   out <- NULL
-  uid <- paste(sample(c(letters,LETTERS),8, replace=TRUE),sep="", collapse="")
-  tmpfile <- paste("/tmp/RMINC-",uid,".txt",sep="")
+  tmpfile <- tempfile(pattern="RMINC-", fileext=".txt")
   if (method == "jacobians") {
     system(paste("label_volumes_from_jacobians", atlas, filename, ">", tmpfile, sep=" "))
     out <- read.csv(tmpfile, header=FALSE)
@@ -48,6 +47,7 @@ anatGetFile <- function(filename, atlas, method="jacobians", defs="/projects/mic
     }
     out <- out[out$V1 %in% usedlabels,]
   }
+  on.exit(unlink(tmpfile))
   return(out)
 }
 


### PR DESCRIPTION
This avoids clashes between concurrent instances of anatGetFile calls.

Each time anatGetFile writes to a temporary file, a unique identifier (uid) is created and "RMINC-[uid].txt" is written to in /tmp. The uids are generated randomly using sample(). Assuming perfect random sampling on 10000 anatGetFile calls and subsequent uid generations, there is approximately a 9e-07 chance of a uid collision, which (according to Wikipedia) is slightly greater than the death-by-lightning rate per person per year in Germany. 
