### PR TITLE
Major fix for compatibility with R>=4.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,13 +4,15 @@ Date: 2017-05-31
 Title: Statistical Tools for Medical Imaging NetCDF (MINC) Files
 Authors@R: c(person("Jason", "Lerch", role = "aut", email = "jason.lerch@sickkids.ca"), 
              person("Chris", "Hammill", role = c("aut", "cre"), email = "cfhammill@gmail.com"),
-             person("Matthijs", "van Eede", role = "aut", email = "matthijs.vaneede@sickkids.ca"),
+             person("Matthijs", "van Eede", role = "aut"),
              person("Daniel", "Cassel", role = "aut"),
              person("Jim",  "Nikelski", role = "ctb", email = "nikelski@bic.mni.mcgill.ca"),
-             person("Yohan", "Yee", role = "ctb", email = "yohan.yee@sickkids.ca"),
+             person("Yohan", "Yee", role = "ctb"),
              person("Miriam", "Friedel", role = "ctb"),
-             person("Nick", "Wang", role = "ctb", email = "nick.wang@sickkids.ca"),
-             person("Gabriel", "Devenyi", role = "ctb", email = "gdevenyi@gmail.com"))      
+             person("Nick", "Wang", role = "ctb"),
+             person("Gabriel", "Devenyi", role = "ctb", email = "gdevenyi@gmail.com"),
+	     person("Benjamin", "Darwin", role = "ctb")
+	     person("Bilal", "Syed", role = "ctb"))
 Description: Tools for reading, writing, analyzing, and visualizing Medical
     Imaging NetCDF (MINC) files with R.
 Additional_repositories: http://bioconductor.org/packages/3.10/bioc
@@ -55,7 +57,7 @@ SystemRequirements: lsof AND EITHER
     cmake (> 2.6),
     git,
     linux_apt: libhdf5-dev
-    mac_brew: homebrew/science/hdf5
+    mac_brew: homebrew/hdf5
 License: BSD_3_clause + file LICENSE
 LazyLoad: yes
 OS_type: unix

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RMINC
-Version: 1.5.2.3
+Version: 1.5.3.0
 Date: 2017-05-31
 Title: Statistical Tools for Medical Imaging NetCDF (MINC) Files
 Authors@R: c(person("Jason", "Lerch", role = "aut", email = "jason.lerch@sickkids.ca"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person("Jason", "Lerch", role = "aut", email = "jason.lerch@sickkid
              person("Miriam", "Friedel", role = "ctb"),
              person("Nick", "Wang", role = "ctb"),
              person("Gabriel", "Devenyi", role = "ctb", email = "gdevenyi@gmail.com"),
-	     person("Benjamin", "Darwin", role = "ctb")
+	     person("Benjamin", "Darwin", role = "ctb"),
 	     person("Bilal", "Syed", role = "ctb"))
 Description: Tools for reading, writing, analyzing, and visualizing Medical
     Imaging NetCDF (MINC) files with R.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ OS_type: unix
 BugReports: https://github.com/Mouse-Imaging-Centre/RMINC/issues
 URL: https://github.com/Mouse-Imaging-Centre/RMINC,
     https://wiki.mouseimaging.ca/display/MICePub/RMINC
-RoxygenNote: 7.0.2
+RoxygenNote: 7.2.3

--- a/INSTALL
+++ b/INSTALL
@@ -1,13 +1,13 @@
 INSTALLATION
 =============
 
-**Currently there is no support for RMINC on windows**
+Currently there is no support for RMINC on Windows, but it is likely possible to install its MINC dependencies via WSL (Windows Subsystem for Linux) following the Linux instructions below.  Please let us know if you've done this and how you did it.
 
 Every effort has been made to make RMINC as easy to install as possible. 
 For most systems, devtools::install_github("Mouse-Imaging-Centre/RMINC") should 
 be all you need to begin experimenting with MINC files in R. For a richer 
-experience, the highly recommended approach is to acquire the minc-toolkit (v2),
-this package will allow you to use command line tools in addition
+experience, the highly recommended approach is to acquire the minc-toolkit (v2).
+This package will allow you to use command line tools in addition
 to RMINC to manipulate minc files.
 
 Binary installers for the toolkit can be acquired from http://bic-mni.github.io/ 
@@ -19,12 +19,12 @@ If the toolkit is found on your system, the installation will be a bit faster.
 If the toolkit is not found on your system RMINC will attempt to install
 libminc (https://github.com/BIC-MNI/libminc) for you. This provides the
 core functionality needed to use RMINC. In order to install libminc
-you need a few dependencies. You need a version of CMake greater the 2.6,
+you need a few dependencies. You need a version of CMake greater than 2.6,
 you will need git installed to fetch the code, and you will need the 
 development headers for HDF5, the file format underlying MINC. 
 The HDF5 header can be acquired on Debian/Ubuntu type linux systems
 with `sudo apt-get install libhdf5-dev`, or with on Mac OSX with
-the brew package manager `brew install homebrew/science/hdf5`. 
+the brew package manager `brew install hdf5@1.10`.
 
 If you find yourself in a position where you need to install these
 dependencies it is probably best to just install the toolkit as
@@ -59,7 +59,7 @@ you can use homebrew to install the Gnu Compiler Collection which
 comes with gfortran
 
 ```
-brew install gcc libssh2 libgit2 libomp libz
+brew install gcc libssh2 libgit2 libomp zlib
 ```
 
 Regardless of how you install gfortran you will need to tell

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 New in Version 1.5.*.*
 =======================
+3.0
+--
+- Disabled buggy matrix mode of anatLm
+- Add explicit configuration file to civet.readCBRAIN
+- Fixed segfault in minc.separation.sizes
+- Add heat smoothing on surface meshes (thanks @DJFernandes)
+- Improved numerical stability in effect size code
+
+
 2.3
 --
 - Fixed mincLmer reinit (formula out of scope bug)

--- a/R/minc_anatomy.R
+++ b/R/minc_anatomy.R
@@ -878,7 +878,6 @@ anatLm <- function(formula, data, anat, subset=NULL, weights = NULL) {
       matrixName = formula[[2]]
       matrixFound = TRUE
       data.matrix.left <- t(anat[mf[,"(rowcount)"],])
-      #data.matrix.left <- vertexTable(filenames)
       data.matrix.right <- t(term)
     }  
   }
@@ -909,7 +908,11 @@ anatLm <- function(formula, data, anat, subset=NULL, weights = NULL) {
     rows = append(rows,matrixName)
   }	
   
-  
+  if(matrixFound){
+    stop("A term in your model is a matrix, this use of `anatLm` is deprecated, "
+       , "Please merge the two anatomy matrices using rowbind or similar and use a group "
+       , "add a group indicator to your `data.frame`")
+  }
   
   # Call subroutine based on whether matrix was found
   if(!matrixFound) {    	

--- a/R/minc_anatomy.R
+++ b/R/minc_anatomy.R
@@ -809,8 +809,14 @@ anatCombineStructures <- function(vols, method = "jacobians",
 #' }
 #' @export
 anatApply <- function(vols, grouping = NULL, method=mean, ...) {
-  if(is.null(grouping))
+  if(is.null(grouping)) {
     grouping <- factor(1)
+  }
+
+  if (!is.factor(grouping)) {
+    warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+    grouping <- as.factor(grouping)
+  }
   
   ngroups <- length(levels(grouping))
   output <- matrix(nrow=ncol(vols), ncol=ngroups)

--- a/R/minc_interface.R
+++ b/R/minc_interface.R
@@ -1344,20 +1344,27 @@ runRMINCTestbed <- function(..., dataPath = getOption("RMINC_DATA_DIR", tempdir(
 #' and \code{wget}
 #' @export
 getRMINCTestData <- function(dataPath = getOption("RMINC_DATA_DIR", tempdir()), method = "libcurl") {
-
-  downloadPath <- file.path(dataPath, "rminctestdata.tar.gz")
+  
+  downloadPath <- file.path(dataPath, "rminctestdata.zip")
   extractedPath <- file.path(dataPath, "rminctestdata/")
 
   if(!file.exists(extractedPath)){
+    
+    # Download test data
     if(!file.exists(downloadPath)){
       dir.create(dataPath, showWarnings = FALSE, recursive = TRUE)
-      download.file("https://wiki.mouseimaging.ca/download/attachments/1654/rminctestdata2.tar.gz",
+      download.file("https://github.com/Mouse-Imaging-Centre/RMINC-test-data/archive/refs/heads/main.zip",
                     destfile = downloadPath,
                     method = method) # changed from "wget" to stop freakouts on mac
     }
   
-    untar(downloadPath, exdir = dataPath)
+    # Extract test data
+    utils::unzip(downloadPath, exdir = dataPath)
+    
+    # Move test data path one directory up, to play nice with the path specs in the testthat test_*.R scripts
+    file.rename(file.path(dataPath, "RMINC-test-data-main/rminctestdata/"), file.path(dataPath, "rminctestdata/"))
   
+    # Fix hardcoded paths
     rectifyPaths <-
       function(file){
         readLines(file) %>%

--- a/R/minc_lmer.R
+++ b/R/minc_lmer.R
@@ -467,9 +467,9 @@ ranef_summary <-
                   , grouping = group_name
                   , se = NULL) %>%
           gather("var", "value", c("tvalue", "beta")) %>%
-          unite_("groupingXgroup", c("grouping", "group"), sep = "") %>%
-          unite_("varXeffectXgroupingXgroup", c("var", "effect", "groupingXgroup"), sep = "-") %>%
-          spread_("varXeffectXgroupingXgroup", "value") %>%
+          unite("groupingXgroup", c("grouping", "group"), sep = "") %>%
+          unite("varXeffectXgroupingXgroup", c("var", "effect", "groupingXgroup"), sep = "-") %>%
+          spread("varXeffectXgroupingXgroup", "value") %>%
           as.matrix %>%
           .[1,]
       }, e = eff, group_name = names(eff), SIMPLIFY = FALSE) %>%

--- a/R/minc_voxel_statistics.R
+++ b/R/minc_voxel_statistics.R
@@ -227,20 +227,22 @@ mincApplyRCPP <-
 #' only works for mincApply, not pMincApply.
 #' @param reduce Whether to filter masked voxels from the resulting object
 #' @details mincApply allows one to execute any R function at every voxel of a
-#' set of files. There are two variants: mincApply, which works
-#' inside the current R session.
-#' Unless the function to be applied takes a single argument a
-#' wrapper function has to be written. This is illustrated in the
-#' examples; briefly, the wrapper function takes a single argument,
-#' called 'x', which will take on the voxel values at every voxel.
-#' The function has to be turned into a string; the quote function
-#' can be very handy. The output of this function also has to be a
+#' set of files. mincApply runs in the current R process; see also 
+#' pMincApply and qMincApply for parallel variants.
+#' Unless the function to be applied takes a single argument,
+#' which will take on the voxel values at every voxel, a
+#' wrapper function has to be written.  The mincApply function also 
+#' supports passing, instead of a function, a quoted expression containing
+#' a free variable 'x', again taking on all voxel values;
+#' this is illustrated in the examples.  (Not this is not supported by pMincApply.)
+#' The output of this function also has to be a
 #' simple vector or scalar.
 #' Note that interpreted R can be very slow. Mindnumbingly slow. It
 #' therefore pays to write optimal functions or, whenever available,
 #' use the optimized equivalents. In other words and to give one
-#' example, use mincLm rather than applying lm, and if lm has to
-#' really be applied, try to use lm.fit rather than plain lm.
+#' example, use mincLm rather than applying lm, and if lm must
+#' be applied, try to use lm.fit rather than plain lm.
+#' Also consider using parallel apply methods.
 #' When using the pbs method, one can also set the options --> TMPDIR,MAX_NODES and WORKDIR
 #' \cr
 #' If you encounter memory issues, it could be due to minc file caching.
@@ -260,7 +262,7 @@ mincApplyRCPP <-
 #' ### run the whole thing in parallel on the local machine
 #' testFunc <- function (x) { return(c(1,2))}
 #' pout <- pMincApply(gf$jacobians_fixed_2, 
-#'                    quote(testFunc(x)),
+#'                    testFunc,
 #'                    workers = 4,
 #'                    global = c('gf','testFunc'))
 #' mincWriteVolume(pout, "pmincOut.mnc")
@@ -271,7 +273,7 @@ mincApplyRCPP <-
 #' testFunc <- function (x) { return(c(1,2))}
 #' options(TMPDIR="/localhd/$PBS_ID")
 #' pout <- pMincApply(gf$jacobians_fixed_2, 
-#'                    quote(testFunc(x)),
+#'                    testFunc,
 #'                    workers = 4,
 #'                    method="pbs",
 #'                    global = c('gf','testFunc'))
@@ -284,7 +286,7 @@ mincApplyRCPP <-
 #' options(MAX_NODES=8)
 #' options(TMP_DIR="/tmp")
 #' pout <- pMincApply(gf$jacobians_fixed_2, 
-#'                    quote(testFunc(x)),
+#'                    testFunc),
 #'                    modules=c("intel","openmpi","R/3.1.1"),
 #'                    workers = 4,
 #'                    method="pbs",

--- a/R/minc_voxel_statistics.R
+++ b/R/minc_voxel_statistics.R
@@ -38,6 +38,7 @@ mincSummary <- function(filenames, grouping=NULL, mask=NULL, method="mean", mask
   if (is.null(grouping)) {
     grouping <- rep(1, length(filenames))
   }
+  
   if (is.null(maskval)) {
     minmask = 1
     maxmask = 99999999
@@ -76,6 +77,14 @@ mincSummary <- function(filenames, grouping=NULL, mask=NULL, method="mean", mask
 #' @describeIn mincSummary mean
 #' @export
 mincMean <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
+  
+  if(!is.null(grouping)) {
+    if (!is.factor(grouping)) {
+      warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+      grouping <- as.factor(grouping)
+    }
+  }
+
   result <- mincSummary(filenames, grouping, mask, method="mean", maskval=maskval)
   return(result)
 }
@@ -83,6 +92,14 @@ mincMean <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
 #' @describeIn mincSummary Variance
 #' @export
 mincVar <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
+  
+  if(!is.null(grouping)) {
+    if (!is.factor(grouping)) {
+      warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+      grouping <- as.factor(grouping)
+    }
+  }
+  
   result <- mincSummary(filenames, grouping, mask, method="var", maskval=maskval)
   return(result)
 }
@@ -90,6 +107,14 @@ mincVar <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
 #' @describeIn mincSummary Sum
 #' @export
 mincSum <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
+  
+  if(!is.null(grouping)) {
+    if (!is.factor(grouping)) {
+      warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+      grouping <- as.factor(grouping)
+    }
+  }
+  
   result <- mincSummary(filenames, grouping, mask, method="sum", maskval=maskval)
   return(result)
 }
@@ -97,6 +122,14 @@ mincSum <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
 #' @describeIn mincSummary Standard Deviation
 #' @export
 mincSd <- function(filenames, grouping=NULL, mask=NULL, maskval=NULL) {
+  
+  if(!is.null(grouping)) {
+    if (!is.factor(grouping)) {
+      warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+      grouping <- as.factor(grouping)
+    }
+  }
+  
   result <- mincSummary(filenames, grouping, mask, method="var", maskval=maskval)
   result <- sqrt(result)
   return(result)
@@ -779,6 +812,7 @@ mincTtest <- function(filenames, grouping, mask=NULL, maskval=NULL) {
   # the grouping for a t test should only contain 2 groups. Should 
   # also be converted to a factor if it's not.
   if( ! is.factor(grouping) ){
+    warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
     grouping <- as.factor(grouping)
   }
   if(length(levels(grouping)) != 2 ){
@@ -825,6 +859,7 @@ mincPairedTtest <- function(filenames, grouping, mask=NULL, maskval=NULL) {
   # group 1 is paired with element 1 from group 2 etc.), the groups need to have 
   # the same length.
   if( ! is.factor(grouping) ){
+    warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
     grouping <- as.factor(grouping)
   }
   if(length(levels(grouping)) != 2 ){
@@ -873,6 +908,10 @@ mincPairedTtest <- function(filenames, grouping, mask=NULL, maskval=NULL) {
 #' }
 #' @export
 mincWilcoxon <- function(filenames, grouping, mask=NULL, maskval=NULL) {
+  if( ! is.factor(grouping) ){
+    warning(paste("Coercing", deparse(substitute(grouping)), "to a factor\n"))
+    grouping <- as.factor(grouping)
+  }
   result <- mincSummary(filenames, grouping, mask, method="wilcoxon", maskval=maskval)
   result <- as.matrix(result);
   attr(result, "likeVolume") <- filenames[1]

--- a/README
+++ b/README
@@ -3,7 +3,8 @@ focused on the MINC file format. Supports getting
 and writing volumes, running voxel-wise linear models,
 correlations, correcting for multiple comparisons with False Discovery Rate
 control, and more. With contributions from Jason Lerch,
-Chris Hammill, Jim Nikelski, Matthijs van Eede and Daniel Cassel
+Chris Hammill, Jim Nikelski, Matthijs van Eede, Daniel Cassel,
+Yohan Yee, Gabe Devenyi, and Darren Fernandes.
 
 Installation:
 -------------

--- a/RMINC.Rproj
+++ b/RMINC.Rproj
@@ -16,5 +16,5 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --no-lock --no-test-load
 PackageBuildBinaryArgs: --no-multiarch --with-keep.source
-PackageCheckArgs: --install-args="--preclean --no-lock" --as-cran
+PackageCheckArgs: --install-args="--preclean" --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/man/anatFDR.Rd
+++ b/man/anatFDR.Rd
@@ -29,8 +29,8 @@ Anatomy False Discovery Rates
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{anatModel}: anatModel
+\item \code{anatFDR(anatModel)}: anatModel
 
-\item \code{anatLmer}: anatLmerModel
+\item \code{anatFDR(anatLmer)}: anatLmerModel
+
 }}
-

--- a/man/anatSummaries.Rd
+++ b/man/anatSummaries.Rd
@@ -29,15 +29,15 @@ These functions are used to compute the mean, standard deviation,
 }
 \section{Functions}{
 \itemize{
-\item \code{anatMean}: mean
+\item \code{anatMean()}: mean
 
-\item \code{anatSum}: sum
+\item \code{anatSum()}: sum
 
-\item \code{anatVar}: variance
+\item \code{anatVar()}: variance
 
-\item \code{anatSd}: standard deviation
+\item \code{anatSd()}: standard deviation
+
 }}
-
 \examples{
 \dontrun{
 getRMINCTestData() 

--- a/man/civet.computeTissueVolumes.Rd
+++ b/man/civet.computeTissueVolumes.Rd
@@ -39,11 +39,11 @@ dividing each of them by the xfm-derived rescaling factor.
 }
 \section{Functions}{
 \itemize{
-\item \code{civet.computeStxTissueVolumes}: standard space
+\item \code{civet.computeStxTissueVolumes()}: standard space
 
-\item \code{civet.computeNativeTissueVolumes}: native space
+\item \code{civet.computeNativeTissueVolumes()}: native space
+
 }}
-
 \examples{
 
 \dontrun{

--- a/man/civet.getFilename.Rd
+++ b/man/civet.getFilename.Rd
@@ -170,39 +170,39 @@ filename(s).
 }
 \section{Functions}{
 \itemize{
-\item \code{civet.getFilenameClassify}: Tissue classification
+\item \code{civet.getFilenameClassify()}: Tissue classification
 
-\item \code{civet.getFilenameGrayMatterPve}: gray matter pve
+\item \code{civet.getFilenameGrayMatterPve()}: gray matter pve
 
-\item \code{civet.getFilenameWhiteMatterPve}: white matter pve
+\item \code{civet.getFilenameWhiteMatterPve()}: white matter pve
 
-\item \code{civet.getFilenameCsfPve}: csf pve
+\item \code{civet.getFilenameCsfPve()}: csf pve
 
-\item \code{civet.getFilenameStxT1}: Standard to T1 transform
+\item \code{civet.getFilenameStxT1()}: Standard to T1 transform
 
-\item \code{civet.getFilenameCerebrumMask}: brain mask
+\item \code{civet.getFilenameCerebrumMask()}: brain mask
 
-\item \code{civet.getFilenameSkullMask}: skull mask
+\item \code{civet.getFilenameSkullMask()}: skull mask
 
-\item \code{civet.getFilenameGrayMatterSurfaces}: gray matter surfaces
+\item \code{civet.getFilenameGrayMatterSurfaces()}: gray matter surfaces
 
-\item \code{civet.getFilenameWhiteMatterSurfaces}: white matter surfaces
+\item \code{civet.getFilenameWhiteMatterSurfaces()}: white matter surfaces
 
-\item \code{civet.getFilenameMidSurfaces}: mid surfaces
+\item \code{civet.getFilenameMidSurfaces()}: mid surfaces
 
-\item \code{civet.getFilenamesCorticalThickness}: cortical thickness
+\item \code{civet.getFilenamesCorticalThickness()}: cortical thickness
 
-\item \code{civet.getFilenamesCorticalArea}: cortical area
+\item \code{civet.getFilenamesCorticalArea()}: cortical area
 
-\item \code{civet.getFilenamesCorticalVolume}: cortical volume
+\item \code{civet.getFilenamesCorticalVolume()}: cortical volume
 
-\item \code{civet.getFilenameMeanSurfaceCurvature}: surface curvature
+\item \code{civet.getFilenameMeanSurfaceCurvature()}: surface curvature
 
-\item \code{civet.getFilenameLinearTransform}: linear transform
+\item \code{civet.getFilenameLinearTransform()}: linear transform
 
-\item \code{civet.getFilenameNonlinearTransform}: non-linear transform
+\item \code{civet.getFilenameNonlinearTransform()}: non-linear transform
+
 }}
-
 \examples{
 
 \dontrun{

--- a/man/hanatToVisGraph.Rd
+++ b/man/hanatToVisGraph.Rd
@@ -52,6 +52,6 @@ Turns an anatomical tree into a nodes and edges for visNetwork plotting
 }
 \section{Functions}{
 \itemize{
-\item \code{hanatView}: Directly view the graph
-}}
+\item \code{hanatView()}: Directly view the graph
 
+}}

--- a/man/likeVolume.Rd
+++ b/man/likeVolume.Rd
@@ -24,6 +24,6 @@ LikeVolumes control the dimensions of an output minc file.
 }
 \section{Functions}{
 \itemize{
-\item \code{likeVolume<-}: setter
-}}
+\item \code{likeVolume(x) <- value}: setter
 
+}}

--- a/man/maskFile.Rd
+++ b/man/maskFile.Rd
@@ -24,6 +24,6 @@ Mask files control which voxels to perform operations on
 }
 \section{Functions}{
 \itemize{
-\item \code{maskFile<-}: setter
-}}
+\item \code{maskFile(x) <- value}: setter
 
+}}

--- a/man/mincApply.Rd
+++ b/man/mincApply.Rd
@@ -40,20 +40,22 @@ Can execute any R function at every voxel for a set of MINC files
 }
 \details{
 mincApply allows one to execute any R function at every voxel of a
-set of files. There are two variants: mincApply, which works
-inside the current R session.
-Unless the function to be applied takes a single argument a
-wrapper function has to be written. This is illustrated in the
-examples; briefly, the wrapper function takes a single argument,
-called 'x', which will take on the voxel values at every voxel.
-The function has to be turned into a string; the quote function
-can be very handy. The output of this function also has to be a
+set of files. mincApply runs in the current R process; see also 
+pMincApply and qMincApply for parallel variants.
+Unless the function to be applied takes a single argument,
+which will take on the voxel values at every voxel, a
+wrapper function has to be written.  The mincApply function also 
+supports passing, instead of a function, a quoted expression containing
+a free variable 'x', again taking on all voxel values;
+this is illustrated in the examples.  (Not this is not supported by pMincApply.)
+The output of this function also has to be a
 simple vector or scalar.
 Note that interpreted R can be very slow. Mindnumbingly slow. It
 therefore pays to write optimal functions or, whenever available,
 use the optimized equivalents. In other words and to give one
-example, use mincLm rather than applying lm, and if lm has to
-really be applied, try to use lm.fit rather than plain lm.
+example, use mincLm rather than applying lm, and if lm must
+be applied, try to use lm.fit rather than plain lm.
+Also consider using parallel apply methods.
 When using the pbs method, one can also set the options --> TMPDIR,MAX_NODES and WORKDIR
 \cr
 If you encounter memory issues, it could be due to minc file caching.
@@ -69,7 +71,7 @@ mincWriteVolume(ma, "means.mnc")
 ### run the whole thing in parallel on the local machine
 testFunc <- function (x) { return(c(1,2))}
 pout <- pMincApply(gf$jacobians_fixed_2, 
-                   quote(testFunc(x)),
+                   testFunc,
                    workers = 4,
                    global = c('gf','testFunc'))
 mincWriteVolume(pout, "pmincOut.mnc")
@@ -80,7 +82,7 @@ gf <- read.csv("/tmp/rminctestdata/test_data_set.csv")
 testFunc <- function (x) { return(c(1,2))}
 options(TMPDIR="/localhd/$PBS_ID")
 pout <- pMincApply(gf$jacobians_fixed_2, 
-                   quote(testFunc(x)),
+                   testFunc,
                    workers = 4,
                    method="pbs",
                    global = c('gf','testFunc'))
@@ -93,7 +95,7 @@ options(WORKDIR="$SCRATCH")
 options(MAX_NODES=8)
 options(TMP_DIR="/tmp")
 pout <- pMincApply(gf$jacobians_fixed_2, 
-                   quote(testFunc(x)),
+                   testFunc),
                    modules=c("intel","openmpi","R/3.1.1"),
                    workers = 4,
                    method="pbs",

--- a/man/mincAttributes.Rd
+++ b/man/mincAttributes.Rd
@@ -25,6 +25,6 @@ except dimension information
 }
 \section{Functions}{
 \itemize{
-\item \code{setMincAttributes}: setter
-}}
+\item \code{setMincAttributes()}: setter
 
+}}

--- a/man/mincFDR.Rd
+++ b/man/mincFDR.Rd
@@ -83,15 +83,15 @@ This function uses the \code{qvalue} package to compute the
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{mincSingleDim}: mincSingleDim
+\item \code{mincFDR(mincSingleDim)}: mincSingleDim
 
-\item \code{mincLogLikRatio}: mincLogLikRatio
+\item \code{mincFDR(mincLogLikRatio)}: mincLogLikRatio
 
-\item \code{mincLmer}: mincLmer
+\item \code{mincFDR(mincLmer)}: mincLmer
 
-\item \code{mincMultiDim}: mincMultiDim
+\item \code{mincFDR(mincMultiDim)}: mincMultiDim
+
 }}
-
 \examples{
 \dontrun{
 getRMINCTestData() 

--- a/man/mincRandomize.Rd
+++ b/man/mincRandomize.Rd
@@ -66,6 +66,6 @@ returbed.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{mincLm}: mincLm
-}}
+\item \code{mincRandomize(mincLm)}: mincLm
 
+}}

--- a/man/mincSummary.Rd
+++ b/man/mincSummary.Rd
@@ -61,17 +61,17 @@ rather than performing it across all volumes as is the default.
 }
 \section{Functions}{
 \itemize{
-\item \code{mincMean}: mean
+\item \code{mincMean()}: mean
 
-\item \code{mincVar}: Variance
+\item \code{mincVar()}: Variance
 
-\item \code{mincSum}: Sum
+\item \code{mincSum()}: Sum
 
-\item \code{mincSd}: Standard Deviation
+\item \code{mincSd()}: Standard Deviation
 
-\item \code{mincCorrelation}: Correlation
+\item \code{mincCorrelation()}: Correlation
+
 }}
-
 \examples{
 \dontrun{
 getRMINCTestData() 

--- a/man/mincTFCE.Rd
+++ b/man/mincTFCE.Rd
@@ -119,12 +119,12 @@ to allow a hybrid cluster/voxel analysis to be performed.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{mincSingleDim}: mincSingleDim
+\item \code{mincTFCE(mincSingleDim)}: mincSingleDim
 
-\item \code{matrix}: matrix
+\item \code{mincTFCE(matrix)}: matrix
 
-\item \code{mincMultiDim}: mincMultiDim
+\item \code{mincTFCE(mincMultiDim)}: mincMultiDim
 
-\item \code{mincLm}: mincLm
+\item \code{mincTFCE(mincLm)}: mincLm
+
 }}
-

--- a/man/mincWriteVolume.Rd
+++ b/man/mincWriteVolume.Rd
@@ -55,13 +55,13 @@ can be viewed or manipulated with the standard MINC tools
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{mincSingleDim}: mincSingleDim
+\item \code{mincWriteVolume(mincSingleDim)}: mincSingleDim
 
-\item \code{mincMultiDim}: mincMultiDim
+\item \code{mincWriteVolume(mincMultiDim)}: mincMultiDim
 
-\item \code{default}: default
+\item \code{mincWriteVolume(default)}: default
+
 }}
-
 \examples{
 \dontrun{
 getRMINCTestData()

--- a/man/minc_history.Rd
+++ b/man/minc_history.Rd
@@ -24,8 +24,8 @@ Retrieve or edit the history of a MINC Volume
 }
 \section{Functions}{
 \itemize{
-\item \code{minc.get.history}: retrieve
+\item \code{minc.get.history()}: retrieve
 
-\item \code{minc.append.history}: append
+\item \code{minc.append.history()}: append
+
 }}
-

--- a/man/qMincApply.Rd
+++ b/man/qMincApply.Rd
@@ -157,13 +157,13 @@ the conf_file argument.
 }
 \section{Functions}{
 \itemize{
-\item \code{qMincRegistry}: registry
+\item \code{qMincRegistry()}: registry
 
-\item \code{qMincMap}: map
+\item \code{qMincMap()}: map
 
-\item \code{qMincReduce}: reduce
+\item \code{qMincReduce()}: reduce
+
 }}
-
 \seealso{
 \url{https://www.jstatsoft.org/article/view/v064i11} \link{pMincApply} \link{mcMincApply}
 }

--- a/man/thresholds.Rd
+++ b/man/thresholds.Rd
@@ -29,8 +29,8 @@ Get Probability Thresholds
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{mincQvals}: mincQvals
+\item \code{thresholds(mincQvals)}: mincQvals
 
-\item \code{minc_randomization}: minc_randomization
+\item \code{thresholds(minc_randomization)}: minc_randomization
+
 }}
-

--- a/man/vertexEffectSize.Rd
+++ b/man/vertexEffectSize.Rd
@@ -36,11 +36,11 @@ treatment coded factor to use as a predictor.
 }
 \section{Functions}{
 \itemize{
-\item \code{mincEffectSize}: mincEffectSize
+\item \code{mincEffectSize()}: mincEffectSize
 
-\item \code{anatEffectSize}: anatEffectSize
+\item \code{anatEffectSize()}: anatEffectSize
+
 }}
-
 \examples{
 \dontrun{
 getRMINCTestData()

--- a/man/vertexFDR.Rd
+++ b/man/vertexFDR.Rd
@@ -30,8 +30,8 @@ Takes the output of a minc modelling function and computes False Discovery Rate 
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{vertexMultiDim}: vertexMultiDim
+\item \code{vertexFDR(vertexMultiDim)}: vertexMultiDim
 
-\item \code{vertexLmer}: vertexLmer
+\item \code{vertexFDR(vertexLmer)}: vertexLmer
+
 }}
-

--- a/man/vertexSummaries.Rd
+++ b/man/vertexSummaries.Rd
@@ -32,15 +32,15 @@ variance of every vertex in a set of vertex files.
 }
 \section{Functions}{
 \itemize{
-\item \code{vertexMean}: mean
+\item \code{vertexMean()}: mean
 
-\item \code{vertexSum}: sum
+\item \code{vertexSum()}: sum
 
-\item \code{vertexVar}: var
+\item \code{vertexVar()}: var
 
-\item \code{vertexSd}: standard deviation
+\item \code{vertexSd()}: standard deviation
+
 }}
-
 \examples{
 
 \dontrun{

--- a/man/vertexTFCE.Rd
+++ b/man/vertexTFCE.Rd
@@ -124,12 +124,12 @@ using the \link[igraph]{as_adj_list} from the igraph library.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{numeric}: numeric
+\item \code{vertexTFCE(numeric)}: numeric
 
-\item \code{matrix}: matrix
+\item \code{vertexTFCE(matrix)}: matrix
 
-\item \code{vertexLm}: vertexLm
+\item \code{vertexTFCE(vertexLm)}: vertexLm
 
-\item \code{character}: character
+\item \code{vertexTFCE(character)}: character
+
 }}
-

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // anat_summary
 List anat_summary(CharacterVector filenames, IntegerVector atlas, std::string method);
 RcppExport SEXP _RMINC_anat_summary(SEXP filenamesSEXP, SEXP atlasSEXP, SEXP methodSEXP) {

--- a/src/minc_reader.c
+++ b/src/minc_reader.c
@@ -236,14 +236,13 @@ SEXP get_minc_separations(SEXP filename) {
   mihandle_t         hvol;
   const char *filepath = CHAR(asChar(filename));
   midimhandle_t dimensions[3];
-  double* voxel_separations = malloc(3 * sizeof(double));
+  double* voxel_separations = (double *)R_alloc(3, sizeof(double));
   SEXP output = PROTECT(allocVector(REALSXP, 3));
   
   result = miopen_volume(filepath,
                          MI2_OPEN_READ, &hvol);
-  
+
   if (result != MI_NOERROR) {
-    miclose_volume(hvol);
     error("Error opening input file: %s.\n", filepath);
   }
   
@@ -316,7 +315,7 @@ void get_hyperslab(char **filename, int *start, int *count, double *slab) {
 				 MI_TYPE_DOUBLE, 
 				 (misize_t *) tmp_start, 
 				 (misize_t *) tmp_count, 
-				 slab)
+	    			 slab)
       < 0) {
     error("Could not get hyperslab.\n");
   }

--- a/src/modelling_functions.c
+++ b/src/modelling_functions.c
@@ -1,6 +1,14 @@
+#ifndef  USE_FC_LEN_T
+# define USE_FC_LEN_T
+#endif
+
 #include "minc_reader.h"
 #include "R_ext/Lapack.h"
 #include "R_ext/Applic.h"
+
+#ifndef FCONE
+# define FCONE
+#endif
 
 /* minimum computation to speed up bits of qvalue */
 
@@ -538,7 +546,7 @@ SEXP voxel_lm(SEXP Sy, SEXP Sx,int n,int p,double *coefficients,
   // definite matrix A using the Cholesky factorization A =
   // U**T*U or A = L*L**T computed by DPOTRF
   int info;
-  F77_CALL(dpotri)("Upper", &p, x, &n, &info);
+  F77_CALL(dpotri)("Upper", &p, x, &n, &info FCONE);
 
   if (info != 0) {
     UNPROTECT(nprot);

--- a/src/weighted_least_squares.c
+++ b/src/weighted_least_squares.c
@@ -1,7 +1,15 @@
+#ifndef  USE_FC_LEN_T
+# define USE_FC_LEN_T
+#endif
+
 #include <stdio.h>
 #include "modelling_functions.h"
 #include "R_ext/Lapack.h"
 #include "R_ext/Applic.h"
+
+#ifndef FCONE
+# define FCONE
+#endif
 
 SEXP voxel_wlm(SEXP Sy, SEXP Sx, SEXP ws, int n,int p,double *coefficients, 
               double *residuals, double *effects, 
@@ -125,7 +133,7 @@ SEXP voxel_wlm(SEXP Sy, SEXP Sx, SEXP ws, int n,int p,double *coefficients,
   // definite matrix A using the Cholesky factorization A =
   // U**T*U or A = L*L**T computed by DPOTRF
   int info;
-  F77_CALL(dpotri)("Upper", &p, x, &n, &info);
+  F77_CALL(dpotri)("Upper", &p, x, &n, &info FCONE);
   
   if (info != 0) {
     UNPROTECT(nprot);

--- a/tests/testthat/test_anatApply.R
+++ b/tests/testthat/test_anatApply.R
@@ -1,9 +1,10 @@
 library(testthat)
 context("anatApply")
 
-if(!exists("dataPath"))
+if(!exists("dataPath")) {
   dataPath <- tempdir()
-
+}
+  
 getRMINCTestData(dataPath)
 dataPath <- file.path(dataPath, "rminctestdata/")
 

--- a/tests/testthat/test_anatGet.R
+++ b/tests/testthat/test_anatGet.R
@@ -317,6 +317,11 @@ test_that("anatomy hierarchy works", {
 ## Test anatToVolume
 test_that("Test anatToVolume works", {
   evalq({
+    
+    verboseRun(
+      new_jacobians <- anatGetAll(gf$jacobians_0.2, defs = labels, atlas = segmentation, method = "jacobians")
+    )
+    
     seg <- mincGetVolume(segmentation)
     mlm <- anatLm(~ a, data.frame(a = new_jacobians[,1]), new_jacobians)
     vol <- anatToVolume(mlm        
@@ -334,3 +339,4 @@ test_that("Test anatToVolume works", {
     expect_true(all(corrects$correct))
     }, envir = test_env)
 })
+

--- a/tests/testthat/test_anatLm.R
+++ b/tests/testthat/test_anatLm.R
@@ -119,3 +119,12 @@ test_that("Weighted anatLm works", {
   expect_equivalent(sapply(lmods, AIC), AIC(alm))
 })
 
+context("Matrix mode")
+
+test_that("Test that passing a matrix on the RHS fails", {
+  d <- data.frame(y = rnorm(10))
+  d$x <- scale(rnorm(10))
+
+  expect_error(anatLm(~ x, data = d, anat = as.matrix(d$y)), "matrix")
+})
+

--- a/tests/testthat/test_anatLmer.R
+++ b/tests/testthat/test_anatLmer.R
@@ -12,9 +12,10 @@ handle_conv_warnings <- function(expr){
 
 context("anatLmer")
 
-if(!exists("dataPath"))
+if(!exists("dataPath")) {
   dataPath <- tempdir()
-
+}
+  
 getRMINCTestData(dataPath)
 dataPath <- file.path(dataPath, "rminctestdata/")
 
@@ -72,25 +73,16 @@ test_that("anatLmer estimate DF returns sensible results", {
 
 test_that("anatLmer exotic formulae work", {
   evalq({
-    handle_conv_warnings({
-      verboseRun(
-        exotic_lmer <- anatLmer(~ I(factor(as.numeric(Pain.sensitivity) - 1)) + (1 | Genotype)
-                              , data = gf, anat = jacobians)
-      )
     
-      verboseRun(with_dfs <- anatLmerEstimateDF(exotic_lmer))
-    })
-    dfs <- attr(with_dfs, "df")
-    expect_true(between(dfs[1], 1, 3))
-    expect_true(all(between(dfs[2:4], 20, 31)))
-  }, envir = anat_env)
-})
-
-test_that("anatLmer exotic formulae work", {
-  evalq({
+    jacobians <-
+      anatGetAll(gf$jacobians_0.2, 
+                 atlas = segmentation, 
+                 method = "jacobians",
+                 defs = labels)
+    
     handle_conv_warnings({
       verboseRun(
-        exotic_lmer <- anatLmer(~ I(factor(as.numeric(Pain.sensitivity) - 1)) + (1 | Genotype)
+        exotic_lmer <- anatLmer(~ I(factor(as.numeric(as.factor(Pain.sensitivity)) - 1)) + (1 | Genotype)
                               , data = gf, anat = jacobians)
       )
     

--- a/tests/testthat/test_mincLmer.R
+++ b/tests/testthat/test_mincLmer.R
@@ -136,7 +136,7 @@ test_that("Local parallel mincLmer works", {
 test_that("Exotic formulae work", {
   handle_conv_warnings({
     verboseRun({
-      exotic <- mincLmer(jacobians_fixed_2 ~ I(factor(as.numeric(Sex) - 1)) + (1|coil), gf, mask=maskfile)
+      exotic <- mincLmer(jacobians_fixed_2 ~ I(factor(as.numeric(as.factor(Sex)) - 1)) + (1|coil), gf, mask=maskfile)
       exotic_dfs <- mincLmerEstimateDF(exotic)
       df <- attr(exotic_dfs, "df")
     })

--- a/tests/testthat/test_mincSummary.R
+++ b/tests/testthat/test_mincSummary.R
@@ -3,9 +3,10 @@ library(testthat)
 # mincMean, mincSd, mincVar, mincSum 
 context("mincSummary (Mean, Sd, Var, Sum,t-test,correlation,wilcoxon)")
 
-if(!exists("dataPath"))
+if(!exists("dataPath")) {
   dataPath <- tempdir()
-
+}
+  
 getRMINCTestData(dataPath)
 dataPath <- file.path(dataPath, "rminctestdata/")
 
@@ -31,10 +32,10 @@ vt <- tapply(gf$vox, gf$Strain, var)
 s2t <- tapply(gf$vox, gf$Strain, sum)
 
 test_that("mincSummary functions", {
-    expect_equal(mean(gf$vox), mm[1,1])
-    expect_equal(sd(gf$vox), ms[1,1])
-    expect_equal(var(gf$vox), mv[1,1])
-    expect_equal(sum(gf$vox), ms2[1,1])
+    expect_equal(mean(gf$vox), mm[[1,1]])
+    expect_equal(sd(gf$vox), ms[[1,1]])
+    expect_equal(var(gf$vox), mv[[1,1]])
+    expect_equal(sum(gf$vox), ms2[[1,1]])
     expect_equal(mt[1], mms[1,1])
     expect_equal(mt[2], mms[1,2])
     expect_equal(st[1], mss[1,1])

--- a/tests/testthat/test_mincTFCE.R
+++ b/tests/testthat/test_mincTFCE.R
@@ -35,6 +35,9 @@ test_that("minc single dim TFCE works",{
   skip_on_cran()
   skip_on_travis()
   
+  has_mincstuffs <- as.character(Sys.which("label_volumes_from_jacobians")) != ""
+  skip_if_not(has_mincstuffs)
+  
   evalq({
     tfce_vol <- mincTFCE(first_vol)
     expect_equal(example_values, tfce_vol[test_voxels])
@@ -54,7 +57,11 @@ test_that("minc multi dim TFCE works", {
   skip_on_cran()
   skip_on_travis()
   
+  has_mincstuffs <- as.character(Sys.which("label_volumes_from_jacobians")) != ""
+  skip_if_not(has_mincstuffs)
+  
   evalq({
+    
     md_tfce <- mincTFCE(test_multidim)
     expect_equal(md_tfce[test_voxels,1], example_values)
     expect_equal(md_tfce[test_voxels,2], example_values)
@@ -70,6 +77,9 @@ test_that("lm randomization works", {
   evalq({
     skip_on_cran()
     skip_on_travis()
+    
+    has_mincstuffs <- as.character(Sys.which("label_volumes_from_jacobians")) != ""
+    skip_if_not(has_mincstuffs)
     
     verboseRun(lmod <- mincLm(jacobians_0.2 ~ Genotype, gf))
     verboseRun(randomization_results <- mincTFCE(lmod, R = 10))
@@ -89,6 +99,9 @@ test_that("Vertex TFCE approximately matches mincTFCE", {
   skip_on_cran()
   skip_on_travis()
   
+  has_mincstuffs <- as.character(Sys.which("label_volumes_from_jacobians")) != ""
+  skip_if_not(has_mincstuffs)
+  
   tfce_vol <- mincTFCE(first_vol, d = .0027)
   vtfce <- vertexTFCE(first_vol, RMINC:::neighbour_list(15,15,15,6), weights = .001)
   expect_false(any(abs(vtfce - tfce_vol) > 1e-4))
@@ -97,3 +110,4 @@ test_that("Vertex TFCE approximately matches mincTFCE", {
 
 # mincPlotSliceSeries(mincArray(tfce_vol))
 # mincPlotSliceSeries(mincArray(`likeVolume<-`(vtfce, first_file)))
+

--- a/tests/testthat/test_mincTable.R
+++ b/tests/testthat/test_mincTable.R
@@ -1,8 +1,9 @@
 library(testthat)
 context("mincTable")
 
-if(!exists("dataPath"))
+if(!exists("dataPath")) {
   dataPath <- tempdir()
+}
 
 getRMINCTestData(dataPath)
 dataPath <- file.path(dataPath, "rminctestdata/")
@@ -20,11 +21,11 @@ mt_back <- mincTable(gf$jacobians_fixed, file_backed = TRUE)
 mt_back_masked <- mincTable(gf$jacobians_fixed, mask = maskfile, file_backed = TRUE)
 
 test_that("Unmasked mincTable works", {
-  expect_equal(ref, mt)
-  expect_equal(ref, mt_back[,])
+  expect_equivalent(ref, mt)
+  expect_equivalent(ref, mt_back[,])
 })
 
 test_that("Masked mincTable works", {
-  expect_equal(ref_masked, mt_masked)
-  expect_equal(ref_masked, mt_back_masked[,])
+  expect_equivalent(ref_masked, mt_masked)
+  expect_equivalent(ref_masked, mt_back_masked[,])
 })


### PR DESCRIPTION
Fixes the issue caused by hidden length arguments in R>=4.3.0, and addresses issue #314 . Some other minor edits include:
- updating RMINCTestData location
- convert groupings to factors when necessary (possibly related to #309 ?) and throw a warning when this happens
- minor modifications to tests (addresses #296 )

Successfully built with no failing tests on:
1. R=4.3.0, x86_64-pc-linux-gnu (64-bit), Manjaro Linux
2. R=3.6.3, x86_64-pc-linux-gnu (64-bit), Ubuntu 18.04.6 LTS