### PR TITLE
Fix registry_name typo in qMincApplyParallel (#12)

### DIFF
--- a/R/minc_parallel.R
+++ b/R/minc_parallel.R
@@ -187,7 +187,7 @@ pMincApply <-
         cleanup = cleanup,
         conf_file = conf_file,
         registry_dir = registry_dir,
-        registy_name = registry_name
+        registry_name = registry_name
       )
     }
 


### PR DESCRIPTION
https://github.com/gdevenyi/RMINC/issues/12