### PR TITLE
Fix mincGetWorldVoxel rounding (#316)

### DIFF
--- a/src/minc_reader.c
+++ b/src/minc_reader.c
@@ -172,9 +172,11 @@ void get_world_voxel_from_files(char **filenames, int *num_files,
     }
 
     miconvert_world_to_voxel(hvol, location, voxel_coord_tmp);
-    
+
     for (j=0; j < 3; j++) {
-      voxel_coord[j] = (unsigned long) voxel_coord_tmp[j] + 0.5;
+      /* round to nearest voxel: parens needed so + 0.5 happens before
+       * the unsigned-long cast truncates */
+      voxel_coord[j] = (unsigned long) (voxel_coord_tmp[j] + 0.5);
     }
     result = miget_real_value(hvol, voxel_coord, 3, &voxel[i]);
 


### PR DESCRIPTION
Operator precedence parsed
  `(unsigned long) voxel_coord_tmp[j] + 0.5`
as `((unsigned long) voxel_coord_tmp[j]) + 0.5`, truncating before adding 0.5 and then truncating again on the unsigned-long assignment. The +0.5 was a no-op and the line collapsed to floor(), making mincGetWorldVoxel return the wrong voxel for fractional world coordinates that fall in the second half of a sample (e.g. world 0.9 returned voxel 0 instead of 1).

Add the parentheses so 0.5 is added before truncation, restoring the intended round-to-nearest-voxel behaviour and aligning with mincConvertWorldToVoxel and Display.