### PR TITLE
Fix lapack r46

### DIFF
--- a/src/modelling_functions.c
+++ b/src/modelling_functions.c
@@ -1,6 +1,8 @@
 #include "minc_reader.h"
 #include "R_ext/Lapack.h"
 #include "R_ext/Applic.h"
+#include <string.h>
+#include <Rversion.h>
 
 /* minimum computation to speed up bits of qvalue */
 

--- a/src/modelling_functions.c
+++ b/src/modelling_functions.c
@@ -538,7 +538,12 @@ SEXP voxel_lm(SEXP Sy, SEXP Sx,int n,int p,double *coefficients,
   // definite matrix A using the Cholesky factorization A =
   // U**T*U or A = L*L**T computed by DPOTRF
   int info;
-  F77_CALL(dpotri)("Upper", &p, x, &n, &info);
+
+  #if R_VERSION >= R_Version(4,2,0)
+    F77_CALL(dpotri)("Upper", &p, x, &n, &info, strlen("Upper"));
+  #else
+    F77_CALL(dpotri)("Upper", &p, x, &n, &info);
+  #endif
 
   if (info != 0) {
     UNPROTECT(nprot);


### PR DESCRIPTION

### Problem
RMINC fails to compile on R >= 4.2 due to changes in the LAPACK interface.

Specifically, compilation fails with:

error: too few arguments to function 'dpotri_'

### Cause
The LAPACK routine `dpotri` now requires an additional hidden string-length argument in newer R versions.

### Fix
Adds a version-aware conditional call
Uses the legacy call for older R versions
Adds the required string-length argument for R >= 4.2

```c
#if R_VERSION >= R_Version(4,2,0)
    F77_CALL(dpotri)("Upper", &p, x, &n, &info, strlen("Upper"));
#else
    F77_CALL(dpotri)("Upper", &p, x, &n, &info);
#endif
