### PR TITLE
Replace std::bind1st with lambda for C++17 compatibility

### DIFF
--- a/src/vertex_tfce.cpp
+++ b/src/vertex_tfce.cpp
@@ -150,7 +150,7 @@ std::vector<double> graph_tfce(std::vector<double> map, std::vector<std::vector<
                                      , double E, double H, int nsteps
                                      , std::vector<double> weights){
  std::vector<double> pos = graph_tfce_wqu(map, adjacencies, E, H, nsteps, weights);
- std::transform(map.begin(), map.end(), map.begin(), std::bind1st(std::multiplies<double>(), -1));
+  std::transform(map.begin(), map.end(), map.begin(), [](double x) { return -x; });
  std::vector<double> neg = graph_tfce_wqu(map, adjacencies, E, H, nsteps, weights);
  for(int i = 0; i < pos.size(); ++i) pos[i] -= neg[i];
  return pos;


### PR DESCRIPTION
## Fix

`std::bind1st` was removed in C++17 (deprecated in C++11, removed in C++17). The macOS CI compiles with `-std=gnu++20` (Apple Clang 17), causing a build failure:

```
vertex_tfce.cpp:153:59: error: no member named 'bind1st' in namespace 'std'
```

Replace with a simple lambda: `[](double x) { return -x; }`

Fixes the `R-CMD-check (macos-latest, release)` failure in #326.

### What this changes
- `src/vertex_tfce.cpp:153` — one line, functionally identical transformation