### PR TITLE
Fix makeMICeDefsHierachical for R >= 4.2 (closes #335)

### DIFF
--- a/R/minc_hierarchical_anatomy.R
+++ b/R/minc_hierarchical_anatomy.R
@@ -323,7 +323,11 @@ addHierarchyToDefs <- function(defs, tree) {
   for (i in 1:nrow(defs)) {
     tmp <- FindNode(tree, defs$ABI[i])$Get("path")[[1]]
     tmp <- tmp[tmp != "children2"]
-    tmp <- tmp[3:length(tmp)]
+    if (length(tmp) > 2) {
+      tmp <- tmp[3:length(tmp)]
+    } else {
+      tmp <- character(0)
+    }
     Leaf <- as.character(defs$Leaf[i])
     if (defs$ABI[i] == Leaf | defs$name[i] == Leaf) {
       endpath <- as.character(defs$name[i])
@@ -494,10 +498,13 @@ makeMICeDefsHierachical <- function(defs, abijson) {
   # copy important bits from the ABI tree - name and colour especially.
   copyABIinfo(treeMH, tree)
   # propagate the labels so that each structure has a vector of all associated labels
-  treeMH$Do(
-    function(x) x$label <- unlist(Aggregate(x, "label", c)),
-    traversal = "post-order"
-  )
+  collectLabels <- function(node) {
+    if (node$isLeaf) return(node$label)
+    labels <- unlist(lapply(node$children, collectLabels))
+    node$label <- labels
+    return(labels)
+  }
+  collectLabels(treeMH)
 
   return(treeMH)
 }


### PR DESCRIPTION
## Summary

Fixes #335 — `makeMICeDefsHierachical` errors on R >= 4.2 with:

```
Error in length(v) > 0 && !is.na(v) : 'length = 2' in coercion to 'logical(1)'
```

## Changes

### 1. Replace `data.tree::Aggregate` with custom recursive label collection

`data.tree`'s internal `Aggregate` uses `&&` with potentially multi-length vectors. When labels are aggregated into vectors during post-order traversal, `!is.na(v)` returns a multi-length vector, causing `&&` to fail in R >= 4.2 (error in 4.4+, warning in 4.2).

Replaced with a simple recursive function that collects leaf labels and propagates them up the tree.

### 2. Guard short ABI hierarchy paths in `addHierarchyToDefs`

`tmp <- tmp[3:length(tmp)]` blindly strips the first two path elements. For structures near the root of the ABI hierarchy with short paths, this produces invalid `pathString` values (e.g. `tmp[3:2]` gives a reversed empty-ish vector). Added a length guard.